### PR TITLE
Groovie: fast forward all videos

### DIFF
--- a/engines/groovie/groovie.cpp
+++ b/engines/groovie/groovie.cpp
@@ -480,6 +480,9 @@ void SoundEffectQueue::tick() {
 	_file->seek(0);
 	_player->load(_file, 0);
 	_player->playFrame();
+	if (_player->isFastForwarding()) {
+		stopAll();
+	}
 #endif
 }
 

--- a/engines/groovie/player.cpp
+++ b/engines/groovie/player.cpp
@@ -89,6 +89,7 @@ bool VideoPlayer::playFrame() {
 			if (_audioStream->endOfData() || isFastForwarding()) {
 				// Mark the audio stream as finished (no more data will be appended)
 				_audioStream->finish();
+				_audioStream = NULL;
 			} else {
 				// Don't end if there's still audio playing
 				end = false;

--- a/engines/groovie/player.cpp
+++ b/engines/groovie/player.cpp
@@ -26,6 +26,7 @@
 #include "groovie/player.h"
 #include "groovie/groovie.h"
 #include "audio/mixer.h"
+#include "common/debug-channels.h"
 
 namespace Groovie {
 
@@ -62,6 +63,15 @@ void VideoPlayer::setOverrideSpeed(bool isOverride) {
 	}
 }
 
+void VideoPlayer::fastForward() {
+	_millisBetweenFrames = 0;
+	_frameTimeDrift = 0;
+}
+
+bool VideoPlayer::isFastForwarding() {
+	return DebugMan.isDebugChannelEnabled(kDebugFast) || _millisBetweenFrames <= 0;
+}
+
 bool VideoPlayer::playFrame() {
 	bool end = true;
 
@@ -76,7 +86,7 @@ bool VideoPlayer::playFrame() {
 
 		// Wait for pending audio
 		if (_audioStream) {
-			if (_audioStream->endOfData()) {
+			if (_audioStream->endOfData() || isFastForwarding()) {
 				// Mark the audio stream as finished (no more data will be appended)
 				_audioStream->finish();
 			} else {
@@ -90,6 +100,9 @@ bool VideoPlayer::playFrame() {
 }
 
 void VideoPlayer::waitFrame() {
+	if (isFastForwarding()) {
+		return;
+	}
 	uint32 currTime = _syst->getMillis();
 	if (!_begunPlaying) {
 		_begunPlaying = true;

--- a/engines/groovie/player.h
+++ b/engines/groovie/player.h
@@ -43,6 +43,8 @@ public:
 	virtual void resetFlags() {}
 	virtual void setOrigin(int16 x, int16 y) {}
 	virtual void stopAudioStream() = 0;
+	void fastForward();
+	bool isFastForwarding();
 
 protected:
 	// To be implemented by subclasses

--- a/engines/groovie/roq.cpp
+++ b/engines/groovie/roq.cpp
@@ -712,7 +712,7 @@ bool ROQPlayer::processBlockSoundMono(ROQBlockHeader &blockHeader) {
 #ifdef SCUMM_LITTLE_ENDIAN
 	flags |= Audio::FLAG_LITTLE_ENDIAN;
 #endif
-	if (!playFirstFrame())
+	if (!playFirstFrame() && !isFastForwarding())
 		_audioStream->queueBuffer((byte *)buffer, blockHeader.size * 2, DisposeAfterUse::YES, flags);
 	else
 		free(buffer);
@@ -769,7 +769,7 @@ bool ROQPlayer::processBlockSoundStereo(ROQBlockHeader &blockHeader) {
 #ifdef SCUMM_LITTLE_ENDIAN
 	flags |= Audio::FLAG_LITTLE_ENDIAN;
 #endif
-	if (!playFirstFrame())
+	if (!playFirstFrame() && !isFastForwarding())
 		_audioStream->queueBuffer((byte *)buffer, blockHeader.size * 2, DisposeAfterUse::YES, flags);
 	else
 		free(buffer);

--- a/engines/groovie/script.cpp
+++ b/engines/groovie/script.cpp
@@ -725,6 +725,8 @@ bool Script::playvideofromref(uint32 fileref, bool loopUntilAudioDone) {
 
 		// End the playback
 		return true;
+	} else if (_eventMouseClicked == 2) {
+		_vm->_videoPlayer->fastForward();
 	}
 
 	// Video available, play one frame

--- a/engines/groovie/vdx.cpp
+++ b/engines/groovie/vdx.cpp
@@ -185,10 +185,8 @@ bool VDXPlayer::playFrameInternal() {
 	}
 
 	// Wait until the current frame can be shown
+	waitFrame();
 
-	if (!DebugMan.isDebugChannelEnabled(kDebugFast)) {
-		waitFrame();
-	}
 	// TODO: Move it to a better place
 	// Update the screen
 	if (currRes == 0x25) {
@@ -534,7 +532,7 @@ void VDXPlayer::chunkSound(Common::ReadStream *in) {
 	if (getOverrideSpeed())
 		setOverrideSpeed(false);
 
-	if (!_audioStream) {
+	if (!_audioStream && !isFastForwarding()) {
 		_audioStream = Audio::makeQueuingAudioStream(22050, false);
 		Audio::SoundHandle sound_handle;
 		g_system->getMixer()->playStream(Audio::Mixer::kSpeechSoundType, &sound_handle, _audioStream);
@@ -542,8 +540,10 @@ void VDXPlayer::chunkSound(Common::ReadStream *in) {
 
 	byte *data = (byte *)malloc(60000);
 	int chunksize = in->read(data, 60000);
-	if (!DebugMan.isDebugChannelEnabled(kDebugFast)) {
+	if (!isFastForwarding()) {
 		_audioStream->queueBuffer(data, chunksize, DisposeAfterUse::YES, Audio::FLAG_UNSIGNED);
+	} else {
+		free(data);
 	}
 }
 


### PR DESCRIPTION
For videos that don't have a _videoSkipAddress this allows you to fast forward through them. Also allows you to skip audio files line in T11H the riddles and hints.